### PR TITLE
Fix an issue on generating diagrams from Stdin

### DIFF
--- a/markdown_inline_mermaid.py
+++ b/markdown_inline_mermaid.py
@@ -31,7 +31,7 @@ BLOCK_RE = re.compile(
 )
 
 puppeteer_config_content = """{
-  "args": ["--no-sandbox"]
+  "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-gpu"]
 }
 """
 


### PR DESCRIPTION
This fixes an issue when the puppeteer opens chromium and chromium hand up there and then throws an error.

I'm using this in my Dockerfile with TechDocs `markdown-inline-mermaid==1.0.3 ` but it keeps giving me an error:

```
Error : Image not created
Args : ['mmdc', '-p', '/tmp/tmphg83o9_r/puppeteer-config.json', '-o', '/tmp/tmphg83o9_r/out.svg']
stdout : Generating single mermaid chart
stderr : 
No input file specified, reading from stdin. If you want to specify an input file, please use `-i 
.` You can use `-i -` to read from stdin and to suppress this warning.


ProtocolError: Network.enable timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.
```

Patching the script with these flags due to the latest changes in `mermaid-cli` fixes that error for me.